### PR TITLE
Fix pixel<->rectilinear conversion failing on Linux

### DIFF
--- a/src/main/java/komposten/leapjna/leapc/LeapC.java
+++ b/src/main/java/komposten/leapjna/leapc/LeapC.java
@@ -782,7 +782,7 @@ public interface LeapC extends Library
 	 *      API - LeapPixelToRectilinear</a>
 	 */
 	public LEAP_VECTOR.ByValue LeapPixelToRectilinear(Pointer hConnection, int camera,
-			LEAP_VECTOR pixel);
+			LEAP_VECTOR.ByValue pixel);
 
 
 	/**
@@ -823,7 +823,7 @@ public interface LeapC extends Library
 	 *      API - LeapRectilinearToPixel</a>
 	 */
 	public LEAP_VECTOR.ByValue LeapRectilinearToPixel(Pointer hConnection, int camera,
-			LEAP_VECTOR rectilinear);
+			LEAP_VECTOR.ByValue rectilinear);
 
 
 	/**

--- a/src/main/java/komposten/leapjna/leapc/data/LEAP_VECTOR.java
+++ b/src/main/java/komposten/leapjna/leapc/data/LEAP_VECTOR.java
@@ -77,5 +77,11 @@ public class LEAP_VECTOR extends Structure
 		{
 			super();
 		}
+
+
+		public ByValue(float x, float y, float z)
+		{
+			super(x, y, z);
+		}
 	}
 }

--- a/src/test/java/komposten/leapjna/leapc/LeapCTest.java
+++ b/src/test/java/komposten/leapjna/leapc/LeapCTest.java
@@ -1073,7 +1073,7 @@ public class LeapCTest
 	void LeapPixelToRectilinear_correctValues()
 	{
 		int camera = 1;
-		LEAP_VECTOR pixel = new LEAP_VECTOR(1, 2, 3);
+		LEAP_VECTOR.ByValue pixel = new LEAP_VECTOR.ByValue(1, 2, 3);
 		
 		LEAP_VECTOR actual = LeapC.INSTANCE.LeapPixelToRectilinear(getConnectionHandle(),
 				camera, pixel);
@@ -1094,7 +1094,7 @@ public class LeapCTest
 	void LeapRectilinearToPixel_correctValues()
 	{
 		int camera = 1;
-		LEAP_VECTOR rectilinear = new LEAP_VECTOR(1, 2, 3);
+		LEAP_VECTOR.ByValue rectilinear = new LEAP_VECTOR.ByValue(1, 2, 3);
 		
 		LEAP_VECTOR actual = LeapC.INSTANCE.LeapRectilinearToPixel(getConnectionHandle(),
 				camera, rectilinear);


### PR DESCRIPTION
This was caused by not passing the LEAP_VECTOR parameter by value.